### PR TITLE
Removed the encoding to avoid false error

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "pdf"
     ],
     "peerDependencies": {
-        "cordova-plugin-file": "^3.0.0"
+        "cordova-plugin-file": "^4.0.0"
     },
     "author": "Polar Cape <info@polarcape.com> (http://polarcape.com/)",
     "license": "MIT",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
  
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
-        id="com.polarcape.plugins.documenthandler"
+        id="polarcape-cordova-plugin-document-handler"
         version="1.0.6">
 
     <engines>

--- a/www/DocumentHandler.js
+++ b/www/DocumentHandler.js
@@ -71,7 +71,6 @@ var DocumentViewer = {
         });
     },
     previewFileFromUrlOrPath: function (successHandler, failureHandler, url, fileName) {
-		url = encodeURI(url);
         viewDocument(successHandler, failureHandler, url, fileName);
     }
 };


### PR DESCRIPTION
Whenever the url contained a query string, encoding will make `dataWithContentsOfURL` returning `nil`