### PR TITLE
Document handler js error fix, package.json main update

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "polarcape-cordova-plugin-document-handler",
   "version": "1.0.13",
   "description": "A phonegap plugin to handle documents (f.e. PDFs) loaded from a URL.",
-  "main": "index.js",
+  "main": "www/DocumentHandler.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/www/DocumentHandler.js
+++ b/www/DocumentHandler.js
@@ -1,81 +1,84 @@
-var viewDocument = function (
-        successHandler,
-        failureHandler,
-        url, fileName) {
-    cordova.exec(
+;( function () {
+    var viewDocument = function (
             successHandler,
             failureHandler,
-            "DocumentHandler",
-            "HandleDocumentWithURL",
-            [{"url": url, "fileName":fileName}]);
-};
+            url, fileName) {
+        cordova.exec(
+                successHandler,
+                failureHandler,
+                "DocumentHandler",
+                "HandleDocumentWithURL",
+                [{"url": url, "fileName":fileName}]);
+    };
 
-var b64toBlob = function (b64Data, contentType, sliceSize) {
-    contentType = contentType || '';
-    sliceSize = sliceSize || 512;
+    var b64toBlob = function (b64Data, contentType, sliceSize) {
+        contentType = contentType || '';
+        sliceSize = sliceSize || 512;
 
-    var byteCharacters = atob(b64Data);
-    var byteArrays = [];
+        var byteCharacters = atob(b64Data);
+        var byteArrays = [];
 
-    for (var offset = 0; offset < byteCharacters.length; offset += sliceSize) {
-        var slice = byteCharacters.slice(offset, offset + sliceSize);
+        for (var offset = 0; offset < byteCharacters.length; offset += sliceSize) {
+            var slice = byteCharacters.slice(offset, offset + sliceSize);
 
-        var byteNumbers = new Array(slice.length);
-        for (var i = 0; i < slice.length; i++) {
-            byteNumbers[i] = slice.charCodeAt(i);
+            var byteNumbers = new Array(slice.length);
+            for (var i = 0; i < slice.length; i++) {
+                byteNumbers[i] = slice.charCodeAt(i);
+            }
+
+            var byteArray = new Uint8Array(byteNumbers);
+
+            byteArrays.push(byteArray);
         }
 
-        var byteArray = new Uint8Array(byteNumbers);
+        var blob = new Blob(byteArrays, {type: contentType});
+        return blob;
+    };
 
-        byteArrays.push(byteArray);
-    }
+    var writeBase64ToFile = function (fileName, data, path, type) {
+        return new Promise(function (resolve, reject) {
+            window.resolveLocalFileSystemURL(path, function (directoryEntry) {
+                directoryEntry.getFile(fileName, {create: true}, function (fileEntry) {
+                    fileEntry.createWriter(function (fileWriter) {
+                        var blob = b64toBlob(data, type);
+                        fileWriter.write(blob);
 
-    var blob = new Blob(byteArrays, {type: contentType});
-    return blob;
-};
+                        fileWriter.onwriteend = function (e) {
+                            resolve(path + fileName);
+                        };
 
-var writeBase64ToFile = function (fileName, data, path, type) {
-    return new Promise(function (resolve, reject) {
-        window.resolveLocalFileSystemURL(path, function (directoryEntry) {
-            directoryEntry.getFile(fileName, {create: true}, function (fileEntry) {
-                fileEntry.createWriter(function (fileWriter) {
-                    var blob = b64toBlob(data, type);
-                    fileWriter.write(blob);
-
-                    fileWriter.onwriteend = function (e) {
-                        resolve(path + fileName);
-                    };
-
-                    fileWriter.onerror = function (e) {
-                        reject(e.toString());
-                    };
+                        fileWriter.onerror = function (e) {
+                            reject(e.toString());
+                        };
+                    }, function (error) {
+                        reject(error);
+                    });
                 }, function (error) {
                     reject(error);
                 });
             }, function (error) {
                 reject(error);
             });
-        }, function (error) {
-            reject(error);
         });
-    });
-};
+    };
 
-var DocumentViewer = {
-    saveAndPreviewBase64File: function (successHandler, failureHandler, data, type, path, fileName) {
-        writeBase64ToFile(fileName, data, path, type).then(
-                function (response) {
-                    viewDocument(successHandler, failureHandler, path + fileName, fileName);
-                }, function (error) {
-            failureHandler('Error');
-        });
-    },
-    previewFileFromUrlOrPath: function (successHandler, failureHandler, url, fileName) {
-        viewDocument(successHandler, failureHandler, url, fileName);
+    var DocumentViewer = {
+        saveAndPreviewBase64File: function (successHandler, failureHandler, data, type, path, fileName) {
+            writeBase64ToFile(fileName, data, path, type).then(
+                    function (response) {
+                        viewDocument(successHandler, failureHandler, path + fileName, fileName);
+                    }, function (error) {
+                failureHandler('Error');
+            });
+        },
+        previewFileFromUrlOrPath: function (successHandler, failureHandler, url, fileName) {
+            viewDocument(successHandler, failureHandler, url, fileName);
+        }
+    };
+
+    window.DocumentViewer = DocumentViewer;
+    
+    if (window.module && window.module.exports) {
+        window.module.exports = DocumentViewer;
     }
-};
-
-if (module && module.exports) {
-    module.exports = DocumentViewer;
-}
-
+} ) ();


### PR DESCRIPTION
JS errors were occurring due to outright reference to module when module did not exist in the global scope. Changing to reference as property of window to avoid JS errors.

Also updating package.json's main property to point to www/DocumentHandler.js, which should be the entry point rather than index.js which does not exist.

@vkajtazov can you please review?