### PR TITLE
Update README to reflect new window object name

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ This plugin depends on cordova-plugin-file. If you want to install this plugin y
 
 The plugin exposes two methods on the window object: 
     
-     DocumentHandler.previewFileFromUrlOrPath(successHandler, failureHandler, url, fileName)
+     DocumentViewer.previewFileFromUrlOrPath(successHandler, failureHandler, url, fileName)
 
-     DocumentHandler.saveAndPreviewBase64File(successHandler, failureHandler, data, type, path, fileName)
+     DocumentViewer.saveAndPreviewBase64File(successHandler, failureHandler, data, type, path, fileName)
 
 The parameters: 
 
@@ -61,7 +61,7 @@ Choose one from the following:
 
 ## Example 1
 
-    DocumentHandler.previewFileFromUrlOrPath(
+    DocumentViewer.previewFileFromUrlOrPath(
         function () {
         console.log('success');
         }, function (error) {
@@ -76,7 +76,7 @@ Choose one from the following:
 
 ## Example 2
 
-    DocumentHandler.saveAndPreviewBase64File(
+    DocumentViewer.saveAndPreviewBase64File(
         function (success) {},
         function (error) {
             if (error == 53) {


### PR DESCRIPTION
In the current version the JS object that is written into `window` is called `DocumentViewer`. The README still used the old `DocumentHandler` name.