### PR TITLE
(android) added file type parameter to preview

### DIFF
--- a/src/android/DocumentHandler.java
+++ b/src/android/DocumentHandler.java
@@ -43,12 +43,13 @@ public class DocumentHandler extends CordovaPlugin {
             // parse arguments
             final JSONObject arg_object = args.getJSONObject(0);
             final String url = arg_object.getString("url");
-            final String fileName =arg_object.getString("fileName") ;
+            final String fileName = arg_object.getString("fileName");
+            final String type = arg_object.getString("type");
 			FILE_PROVIDER_PACKAGE_ID = cordova.getActivity().getPackageName() + ".fileprovider";
             System.out.println("Found: " + url);
 
             // start async download task
-            new FileDownloaderAsyncTask(callbackContext, url, fileName).execute();
+            new FileDownloaderAsyncTask(callbackContext, url, fileName, type).execute();
 
             return true;
         }
@@ -148,13 +149,15 @@ public class DocumentHandler extends CordovaPlugin {
         private final CallbackContext callbackContext;
         private final String url;
         private final String fileName;
+        private final String type;
 
         public FileDownloaderAsyncTask(CallbackContext callbackContext,
-                String url, String fileName) {
+                String url, String fileName, String type) {
             super();
             this.callbackContext = callbackContext;
             this.url = url;
             this.fileName = fileName;
+            this.type = type;
         }
 
         @Override
@@ -177,7 +180,8 @@ public class DocumentHandler extends CordovaPlugin {
             Context context = cordova.getActivity().getApplicationContext();
 
             // get mime type of file data
-            String mimeType = getMimeType(url);
+            String mimeType = type;
+            if (mimeType.isEmpty()) mimeType = getMimeType(url);
             if (mimeType == null) {
                 callbackContext.error(ERROR_UNKNOWN_ERROR);
                 return;

--- a/src/android/DocumentHandler.java
+++ b/src/android/DocumentHandler.java
@@ -65,7 +65,7 @@ public class DocumentHandler extends CordovaPlugin {
      * @param url
      * @return
      */
-    private File downloadFile(String url, CallbackContext callbackContext) {
+    private File downloadFile(String fileName, String url, CallbackContext callbackContext) {
 
         try {
 			// get an instance of a cookie manager since it has access to our
@@ -86,7 +86,12 @@ public class DocumentHandler extends CordovaPlugin {
 
             InputStream reader = conn.getInputStream();
 
-            String extension = MimeTypeMap.getFileExtensionFromUrl(url);
+            String extension = "";
+            if (fileName.isEmpty()) {
+                extension = MimeTypeMap.getFileExtensionFromUrl(url);
+            } else {
+                extension = fileName;
+            }
             if (extension.equals("")) {
                 extension = "pdf";
                 System.out.println("extension (default): " + extension);
@@ -163,7 +168,7 @@ public class DocumentHandler extends CordovaPlugin {
         @Override
         protected File doInBackground(Void... arg0) {
             if (!url.startsWith("file://")) {
-                return downloadFile(url, callbackContext);
+                return downloadFile(this.fileName, url, callbackContext);
             } else {
                 File file = new File(url.replace("file://", ""));
                 return file;

--- a/www/DocumentHandler.js
+++ b/www/DocumentHandler.js
@@ -2,13 +2,17 @@
     var viewDocument = function (
             successHandler,
             failureHandler,
-            url, fileName) {
+            url, fileName, type) {
         cordova.exec(
                 successHandler,
                 failureHandler,
                 "DocumentHandler",
                 "HandleDocumentWithURL",
-                [{"url": url, "fileName":fileName}]);
+                [{
+                    "url": url,
+                    "fileName": fileName,
+                    "type": type || ""
+                }]);
     };
 
     var b64toBlob = function (b64Data, contentType, sliceSize) {
@@ -66,13 +70,13 @@
         saveAndPreviewBase64File: function (successHandler, failureHandler, data, type, path, fileName) {
             writeBase64ToFile(fileName, data, path, type).then(
                     function (response) {
-                        viewDocument(successHandler, failureHandler, path + fileName, fileName);
+                        viewDocument(successHandler, failureHandler, path + fileName, fileName, type);
                     }, function (error) {
                 failureHandler('Error');
             });
         },
-        previewFileFromUrlOrPath: function (successHandler, failureHandler, url, fileName) {
-            viewDocument(successHandler, failureHandler, url, fileName);
+        previewFileFromUrlOrPath: function (successHandler, failureHandler, url, fileName, type) {
+            viewDocument(successHandler, failureHandler, url, fileName, type);
         }
     };
 


### PR DESCRIPTION
I have a pdf that's served from an internal url that has a ".cls" extension, but actually returns a pdf stream. 
The mime type is calculated incorrectly from the url as ".cls".
I've added the optional `type` parameter to the `previewFileFromUrlOrPath` function, that will override the mime type calculation from url.

Usage example:

```
DocumentViewer.previewFileFromUrlOrPath(
        function () {
        console.log('success');
        }, function (error) {
        if (error == 53) {
            console.log('No app that handles this file type.');
        }else if (error == 2){
            console.log('Invalid link');
        }
    },
    url, 'pdf.pdf', 'application/pdf');
```