### PR TITLE
(ios) not ignoring fileName parameter

### DIFF
--- a/src/ios/DocumentHandler.m
+++ b/src/ios/DocumentHandler.m
@@ -13,7 +13,7 @@
         NSDictionary* dict = [command.arguments objectAtIndex:0];
         
         NSString* urlStr = dict[@"url"];
-        NSString* filename = dict[@"fileName"];
+        NSString* filenameArg = dict[@"fileName"];
         NSString* escaped =  [ urlStr stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
         NSURL* url = [NSURL URLWithString:escaped];
 
@@ -24,7 +24,10 @@
           return;
         }
 
-        NSString* fileName = [url lastPathComponent];
+        NSString* fileName = filenameArg;
+        if ([fileName length] == 0) {
+            fileName = [url lastPathComponent];
+        }
         
         NSString* fileExt = [fileName pathExtension];
         if([fileExt length] == 0){
@@ -46,7 +49,7 @@
         });
         
         
-        CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:filename];
+        CDVPluginResult *commandResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:fileName];
         [weakSelf.commandDelegate sendPluginResult:commandResult callbackId:command.callbackId];
     });
 }


### PR DESCRIPTION
Hi,
Similar to https://github.com/PolarCape/polarcape-cordova-plugin-document-handler/commit/5e1d2136944ebe9de528a0e21b957752a5db4fdf
It will take the file name from argument, and only if no argument is sent will it infer filename from url.