### PR TITLE
Add android xmlns

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
  
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
+	xmlns:android="http://schemas.android.com/apk/res/android"
         id="polarcape-cordova-plugin-document-handler"
         version="1.1.1">
 


### PR DESCRIPTION
Some tools won't parse this file without the proper namespace for the `android:` prefixed attributes.